### PR TITLE
Fix the vim_bootstrap_langs return

### DIFF
--- a/plugin/vim_bootstrap_updater.py
+++ b/plugin/vim_bootstrap_updater.py
@@ -26,6 +26,18 @@ def _generate_vimrc(langs):
     return response.read()
 
 
+def get_available_langs():
+    conn = HTTPConnection('vim-bootstrap.appspot.com')
+    conn.request('GET', '/langs')
+
+    response = conn.getresponse()
+
+    if response.status is not 200:
+        raise Exception()
+
+    return response.read()
+        
+
 def update(langs):
     content = _generate_vimrc(langs)
 

--- a/plugin/vim_bootstrap_updater.vim
+++ b/plugin/vim_bootstrap_updater.vim
@@ -11,12 +11,22 @@ python sys.path.append(vim.eval('expand("<sfile>:h")'))
 function! VimBootstrapUpdate()
 python << endOfPython
 
-from vim_bootstrap_updater import update
+from vim_bootstrap_updater import update, get_available_langs
 
-langs = vim.eval('g:vim_bootstrap_langs').split(',')
-response, content = update(langs)
+try:
+	# read the vim_bootstrap_langs and generate the list
+	# if this variable doens't exist it will generate a 
+	# list with all available languages
+	langs = vim.eval('g:vim_bootstrap_langs').split(',')
+except:
+	langs = get_available_langs().split(',')
 
-print response
+try:
+	update(langs)
+	print '~/.vimrc succesfully updated'
+except Exception as e:
+	print 'error to generate .vimrc'
+	print e
 
 endOfPython
 endfunction


### PR DESCRIPTION
Hi @sherzberg 

This Pull Request fixes the issue #1 

I've made some improves like a GET than returns a list with all available languages if the `vim_bootstrap_langs` not exists. ;)
