### PR TITLE
Use urllib2 instead of HTTPConnection

### DIFF
--- a/plugin/run.py
+++ b/plugin/run.py
@@ -1,5 +1,4 @@
 from vim_bootstrap_updater import *
-from vim_bootstrap_updater import _generate_vimrc
 
 
-print update(['python', 'ruby'])
+print update('vim', ['python', 'ruby'])

--- a/plugin/tests/vim_bootstrap_updater_tests.py
+++ b/plugin/tests/vim_bootstrap_updater_tests.py
@@ -14,11 +14,11 @@ class VimBootstrapUpdaterTests(unittest.TestCase):
         mock_response.read.return_value = 'fake response'
         mock_urlopen.return_value = mock_response
 
-        result = sut._generate_vimrc(['hy', 'closure'])
+        result = sut._generate_vimrc('nvim', ['hy', 'closure'])
 
         self.assertEqual(mock_urlopen.call_args, mock.call(
             'https://vim-bootstrap.appspot.com/generate.vim',
-            'langs=hy&langs=closure'))
+            'langs=hy&langs=closure&editor=nvim'))
         self.assertEqual('fake response', result)
 
     @mock.patch('vim_bootstrap_updater.urllib2.urlopen')
@@ -29,12 +29,11 @@ class VimBootstrapUpdaterTests(unittest.TestCase):
             code=404, msg="Not Found", hdrs=None, fp=None)
 
         with self.assertRaises(urllib2.HTTPError):
-            sut._generate_vimrc(['hy'])
+            sut._generate_vimrc('vim', ['hy'])
 
-    @mock.patch('vim_bootstrap_updater.vimrc_path', return_value='/tmp/.vimrc')
     @mock.patch('vim_bootstrap_updater._generate_vimrc', return_value='fake vimrc')
-    def test_update(self, mock_generate_vimrc, mock_vimrc_path):
-        result = sut.update(['hy'])
+    def test_update(self, mock_generate_vimrc):
+        result = sut.update('/tmp/.vimrc', 'vim', ['hy'])
 
         self.assertEqual('fake vimrc', result)
 

--- a/plugin/tests/vim_bootstrap_updater_tests.py
+++ b/plugin/tests/vim_bootstrap_updater_tests.py
@@ -1,49 +1,38 @@
 import unittest
-from mock import patch, PropertyMock, MagicMock
+import mock
+import urllib2
 import vim_bootstrap_updater as sut
 
 
 class VimBootstrapUpdaterTests(unittest.TestCase):
 
-    def test_generate_params(self):
-        langs = 'hy clojure'.split()
-        result = sut._generate_params(langs)
-
-        self.assertEqual('langs=hy&langs=clojure', result)
-
-    @patch('vim_bootstrap_updater.HTTPConnection')
-    @patch('vim_bootstrap_updater.vimrc_path', return_value='/tmp/.vimrc')
-    @patch('vim_bootstrap_updater._generate_params', return_value='langs=hy')
-    def test_generate_vimrc_200(self, mock_generate_params, mock_VIMRC_PATH, mock_HTTPConnection):
-        mock_conn = MagicMock()
-        mock_HTTPConnection.return_value = mock_conn
-        mock_response = MagicMock()
-        type(mock_response).status = PropertyMock(return_value=200)
+    @mock.patch('vim_bootstrap_updater.urllib2.urlopen')
+    @mock.patch('vim_bootstrap_updater.vimrc_path', return_value='/tmp/.vimrc')
+    def test_generate_vimrc_200(self, mock_VIMRC_PATH, mock_urlopen):
+        mock_response = mock.MagicMock()
+        mock_response.code = 200
         mock_response.read.return_value = 'fake response'
+        mock_urlopen.return_value = mock_response
 
-        mock_conn.getresponse.return_value = mock_response
+        result = sut._generate_vimrc(['hy', 'closure'])
 
-        result = sut._generate_vimrc(['hy'])
-
+        self.assertEqual(mock_urlopen.call_args, mock.call(
+            'https://vim-bootstrap.appspot.com/generate.vim',
+            'langs=hy&langs=closure'))
         self.assertEqual('fake response', result)
 
-    @patch('vim_bootstrap_updater.HTTPConnection')
-    @patch('vim_bootstrap_updater.vimrc_path', return_value='/tmp/.vimrc')
-    @patch('vim_bootstrap_updater._generate_params', return_value='langs=hy')
-    def test_generate_vimrc_NOT_200(self, mock_generate_params, mock_VIMRC_PATH, mock_HTTPConnection):
-        mock_conn = MagicMock()
-        mock_HTTPConnection.return_value = mock_conn
-        mock_response = MagicMock()
-        type(mock_response).status = PropertyMock(return_value=404)
-        mock_response.read.return_value = 'fake response'
+    @mock.patch('vim_bootstrap_updater.urllib2.urlopen')
+    @mock.patch('vim_bootstrap_updater.vimrc_path', return_value='/tmp/.vimrc')
+    def test_generate_vimrc_NOT_200(self, mock_VIMRC_PATH, mock_urlopen):
+        mock_urlopen.side_effect = urllib2.HTTPError(
+            url="https://vim-bootstrap.appspot.com/generate.vim",
+            code=404, msg="Not Found", hdrs=None, fp=None)
 
-        mock_conn.getresponse.return_value = mock_response
-
-        with self.assertRaises(Exception):
+        with self.assertRaises(urllib2.HTTPError):
             sut._generate_vimrc(['hy'])
 
-    @patch('vim_bootstrap_updater.vimrc_path', return_value='/tmp/.vimrc')
-    @patch('vim_bootstrap_updater._generate_vimrc', return_value='fake vimrc')
+    @mock.patch('vim_bootstrap_updater.vimrc_path', return_value='/tmp/.vimrc')
+    @mock.patch('vim_bootstrap_updater._generate_vimrc', return_value='fake vimrc')
     def test_update(self, mock_generate_vimrc, mock_vimrc_path):
         result = sut.update(['hy'])
 

--- a/plugin/vim_bootstrap_updater.py
+++ b/plugin/vim_bootstrap_updater.py
@@ -3,14 +3,16 @@ import urllib
 import urllib2
 
 
-def vimrc_path():
-    return os.path.expanduser('~/.vimrc')
+def vimrc_path(editor):
+    return os.path.expanduser('~/.%src' % editor)
 
 
-def _generate_vimrc(langs):
-    params = urllib.urlencode([('langs', l.strip()) for l in langs])
+def _generate_vimrc(editor, langs):
+    params = [('langs', l.strip()) for l in langs]
+    params.append(('editor', editor))
+    data = urllib.urlencode(params)
     resp = urllib2.urlopen("https://vim-bootstrap.appspot.com/generate.vim",
-                           params)
+                           data)
     return resp.read()
 
 
@@ -19,10 +21,11 @@ def get_available_langs():
     return resp.read()
 
 
-def update(langs):
-    content = _generate_vimrc(langs)
+def update(vimrc, editor, langs):
+    content = _generate_vimrc(editor, langs)
+    vimrc = os.path.expanduser(vimrc)
 
-    with open(vimrc_path(), 'w') as fh:
+    with open(vimrc, 'w') as fh:
         fh.write(str(content))
 
     return content

--- a/plugin/vim_bootstrap_updater.py
+++ b/plugin/vim_bootstrap_updater.py
@@ -1,42 +1,23 @@
 import os
-
-from httplib import HTTPConnection
+import urllib
+import urllib2
 
 
 def vimrc_path():
     return os.path.expanduser('~/.vimrc')
 
 
-def _generate_params(langs):
-    params = '&'.join(['langs={}'.format(lang.strip()) for lang in langs])
-    return params
-
-
 def _generate_vimrc(langs):
-    params = _generate_params(langs)
-
-    conn = HTTPConnection('vim-bootstrap.appspot.com')
-    conn.request('POST', '/generate.vim', params, {})
-
-    response = conn.getresponse()
-
-    if response.status is not 200:
-        raise Exception()
-
-    return response.read()
+    params = urllib.urlencode([('langs', l.strip()) for l in langs])
+    resp = urllib2.urlopen("https://vim-bootstrap.appspot.com/generate.vim",
+                           params)
+    return resp.read()
 
 
 def get_available_langs():
-    conn = HTTPConnection('vim-bootstrap.appspot.com')
-    conn.request('GET', '/langs')
+    resp = urllib2.urlopen("https://vim-bootstrap.appspot.com/langs")
+    return resp.read()
 
-    response = conn.getresponse()
-
-    if response.status is not 200:
-        raise Exception()
-
-    return response.read()
-        
 
 def update(langs):
     content = _generate_vimrc(langs)

--- a/plugin/vim_bootstrap_updater.vim
+++ b/plugin/vim_bootstrap_updater.vim
@@ -2,6 +2,7 @@
 " Add our plugin to the path
 " --------------------------------
 python import sys
+python import os
 python import vim
 python sys.path.append(vim.eval('expand("<sfile>:h")'))
 
@@ -13,19 +14,22 @@ python << endOfPython
 
 from vim_bootstrap_updater import update, get_available_langs
 
-try:
-	# read the vim_bootstrap_langs and generate the list
-	# if this variable doens't exist it will generate a
-	# list with all available languages
-	langs = vim.eval('g:vim_bootstrap_langs').split(',')
-except:
-	langs = get_available_langs().split(',')
+def vim_eval(var, default=None):
+	try:
+		return vim.eval(var)
+	except:
+		return default
+
+langs = vim_eval('g:vim_bootstrap_langs', get_available_langs()).split(',')
+runtime = os.path.basename(os.environ.get('VIM', 'vim'))
+editor = vim_eval('g:vim_bootstrap_editor', runtime)
+vimrc = os.environ.get('MYVIMRC', '~/.%src' % editor)
 
 try:
-	update(langs)
-	print '~/.vimrc succesfully updated'
+	update(vimrc, editor, langs)
+	print '%s succesfully updated' % vimrc
 except Exception as e:
-	print 'error to generate .vimrc'
+	print 'error to generate %s' % vimrc
 	print e
 
 endOfPython

--- a/plugin/vim_bootstrap_updater.vim
+++ b/plugin/vim_bootstrap_updater.vim
@@ -15,7 +15,7 @@ from vim_bootstrap_updater import update, get_available_langs
 
 try:
 	# read the vim_bootstrap_langs and generate the list
-	# if this variable doens't exist it will generate a 
+	# if this variable doens't exist it will generate a
 	# list with all available languages
 	langs = vim.eval('g:vim_bootstrap_langs').split(',')
 except:


### PR DESCRIPTION
urlib2 is a higher level access for http in python and allows for automatic
proxy control as well as error handling greatly simplyfying the code.  Urllib2
was also added in python 2.1 which should cover anything in the wild.
Hopefully no one is running anything less than 2.5 or 2.6.

Also switched the url to https.  Certificate validation is not turned on until
Python 2.7.9 or 3.4.3 but it should help protect a bit against this attack
vector.