### PR TITLE
Remove escapes with backslashes

### DIFF
--- a/plugin/vim_bootstrap_updater.vim
+++ b/plugin/vim_bootstrap_updater.vim
@@ -2,11 +2,11 @@
 "  Function(s)
 " --------------------------------
 function! VimBootstrapUpdate()
-   let langs = join(split(g:vim_bootstrap_langs, ','), '\\&langs=')
+   let langs = join(split(g:vim_bootstrap_langs, ','), '&langs=')
    let editor = g:vim_bootstrap_editor
    let path = $MYVIMRC
-   let data = 'langs='.langs.'\&editor='.editor
-   silent exec '!curl -fLso '.path.' http://vim-bootstrap.com/generate.vim --data '.data | redr!
+   let data = 'langs='.langs.'&editor='.editor
+   silent exec '!curl -fLso '.path.' http://vim-bootstrap.com/generate.vim --data "'.data.'"' | redr!
    echo path.' sucesfully updated! '
 endfunction
 


### PR DESCRIPTION
After https://github.com/avelino/vim-bootstrap-updater/pull/16 was merged, I tried the fix on another notebook (Linux Mint, fish-shell). Fish won't understand the escaped ampersands (`\&`) correctly. I think this could be due to the changes made afterwards: https://github.com/avelino/vim-bootstrap-updater/commit/1fed84a3926c223b1dc54ff822f357d94937d3a2

@cassiobotaro What do you think of this? Seems to work for fish. Can you verify it on your machine?